### PR TITLE
Add Save control, anticipating MLJIteration integration

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,16 @@
 name = "MLJSerialization"
 uuid = "17bed46d-0ab5-4cd4-b792-a5c4b8547c6d"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
+IterationControl = "b3c1a2ee-3fec-4384-bf48-272ea71de57c"
 JLSO = "9da8a3cd-07a3-59c0-a743-3fdc52c30d11"
 MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
 
 [compat]
+IterationControl = "0.3.1"
 JLSO = "2.1"
 MLJBase = "0.18"
 MLJModelInterface = "0.4"
@@ -19,7 +21,10 @@ CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
 DecisionTree = "7806a523-6efd-50cb-b5f6-3fa6f1930dbb"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 MLJScientificTypes = "2e2323e0-db8b-457b-ae0d-bdfb3bc63afd"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["CategoricalArrays", "DecisionTree", "Distributions", "MLJScientificTypes", "Test"]
+test = ["CategoricalArrays", "DecisionTree", "Distributions", "MLJScientificTypes", "Random", "StableRNGs", "Statistics", "Test"]

--- a/src/MLJSerialization.jl
+++ b/src/MLJSerialization.jl
@@ -1,5 +1,9 @@
 module MLJSerialization
 
+# export IterationControl controls:
+export Save
+
 include("machines.jl")
+include("controls.jl")
 
 end # module

--- a/src/controls.jl
+++ b/src/controls.jl
@@ -1,0 +1,37 @@
+import IterationControl
+
+# # SAVE
+
+struct Save{K}
+    filename::String
+    kwargs::K
+end
+
+# constructor:
+Save(filename="machine.jlso"; kwargs...) =
+    Save(filename, kwargs)
+
+IterationControl.@create_docs(Save,
+             header="Save(filename=\"machine.jlso\"; kwargs...)",
+             example="Save(\"run3/machine.jlso\", compression=:gzip)",
+             body="Save the current state of the machine being iterated to "*
+             "disk, using the provided `filename`, decorated with a number, "*
+             "as in \"run3/machine_42.jlso\". The specified `kwargs` "*
+             "are passed to the model-specific serializer "*
+             "(JLSO for most Julia models).\n\n"*
+             "For more on what is meant by \"the machine being iterated\", "*
+             "see [`IteratedModel`](@ref).")
+
+function IterationControl.update!(c::Save,
+                                  ic_model,
+                                  verbosity,
+                                  state=(filenumber=0, ))
+    filenumber = state.filenumber + 1
+    root, suffix = splitext(c.filename)
+    filename = string(root, filenumber, suffix)
+    train_mach = IterationControl.expose(ic_model)
+    verbosity > 0 && @info "Saving \"$filename\". "
+    MLJSerialization.save(filename, train_mach, c.kwargs...)
+    return (filenumber=filenumber, )
+end
+

--- a/test/_dummy_model.jl
+++ b/test/_dummy_model.jl
@@ -1,0 +1,202 @@
+module DummyModel
+
+export DummyIterativeModel, make_dummy
+
+using Random
+using Statistics
+import StableRNGs.LehmerRNG
+using CategoricalArrays
+import Base.==
+
+using MLJModelInterface
+const MMI = MLJModelInterface
+
+
+# AN OBJECT THAT CONSUMES NUMBERS AND GUESSES WHAT'S NEXT BY AVERAGING
+
+mutable struct Guesser
+    avg::Float64 # average so far
+    n::Integer # number of observations so far
+end
+Guesser() = Guesser(0.0, 0)
+
+==(g1::Guesser, g2::Guesser) = g1.avg == g2.avg && g1.n == g2.n
+
+# consume a new number `r`:
+function train!(guesser::Guesser, r)
+    guesser.avg = (guesser.n*guesser.avg + r)/(guesser.n + 1)
+    guesser.n = guesser.n + 1
+end
+
+
+# THE DUMMY MLJ MODEL
+
+# Suppose `X` is a vector with `Finite` elscitype and `y` is a vector
+# of `Continuous` elscitype. `DummyModel` predicts `y` given `X` by
+# randomly sampling from the training data, without replacement, `n`
+# times, and averaging the results for each class of `X`. If
+# `learning_rate` is set to a number different from
+# 1.0, then each target value is increased by `(learning_rate - 1)/n`.
+
+
+mutable struct DummyIterativeModel <: Deterministic
+    n::Int
+    rng::LehmerRNG
+    learning_rate::Float64
+end
+DummyIterativeModel(; n=10,
+                    rng=LehmerRNG(123),
+                    learning_rate=1.0) =
+                        DummyIterativeModel(n,
+                                            rng,
+                                            learning_rate)
+
+# core fitting function:
+function train!(guesser_given_class,
+                n,
+                verbosity,
+                training_losses,
+                rng,
+                global_avg_given_class,
+                learning_rate,
+                X,
+                y)
+    loss = isempty(training_losses) ? Inf : training_losses[end]
+    for _ in 1:n
+        i = rand(rng, eachindex(X))
+        class = X[i]
+        r = y[i]*(1 + (learning_rate - 1)/n)
+        guesser = guesser_given_class[class]
+        train!(guesser, r)
+        global_avg = global_avg_given_class[class]
+        loss = min(abs(guesser.avg - global_avg)/global_avg,
+                   loss)
+        verbosity < 2 || @info "training loss: $loss"
+        push!(training_losses, loss)
+    end
+end
+
+function MMI.fit(model::DummyIterativeModel, verbosity, X, y)
+
+    training_losses = Float64[]
+
+    # cheat to synthesize training losses:
+    global_avg_given_class = Dict(c => mean(y[X .== c]) for c in levels(X))
+
+    # intiate guessers, one per class in `X`:
+    guesser_given_class = Dict(class => Guesser() for class in levels(X))
+
+    loss = Inf
+
+    rng = copy(model.rng)
+
+    train!(guesser_given_class,
+           model.n,
+           verbosity,
+           training_losses,
+           rng,
+           global_avg_given_class,
+           model.learning_rate,
+           X,
+           y)
+
+    fitresult = guesser_given_class
+    report = (training_losses=training_losses, )
+    cache = (rng, deepcopy(model), training_losses, global_avg_given_class)
+
+    return fitresult, cache, report
+
+end
+
+function MMI.update(model::DummyIterativeModel,
+                    verbosity,
+                    fitresult,
+                    cache,
+                    X,
+                    y)
+
+    rng, old_model, training_losses, global_avg_given_class = cache
+    guesser_given_class = fitresult
+
+    Δn = model.n - old_model.n
+
+    # warm restart only for increase in iteration parameter:
+    Δn >= 0 || return fit(model, verbosity, X, y)
+
+    train!(guesser_given_class,
+           Δn,
+           verbosity,
+           training_losses,
+           rng,
+           global_avg_given_class,
+           model.learning_rate,
+           X,
+           y)
+
+    fitresult = guesser_given_class
+    report = (training_losses=training_losses, )
+    cache = (rng, deepcopy(model), training_losses, global_avg_given_class)
+
+    return fitresult, cache, report
+
+end
+
+MMI.predict(::DummyIterativeModel, fitresult, Xnew) =
+    [fitresult[c].avg for c in Xnew]
+
+MMI.iteration_parameter(::Type{<:DummyIterativeModel}) = :n
+MMI.training_losses(::DummyIterativeModel, report) = report.training_losses
+
+MMI.supports_training_losses(::Type{<:DummyIterativeModel}) = true
+MMI.input_scitype(::Type{<:DummyIterativeModel}) =
+    AbstractVector{<:MMI.ScientificTypes.Finite}
+MMI.target_scitype(::Type{<:DummyIterativeModel}) =
+    AbstractVector{<:MMI.ScientificTypes.Continuous}
+
+
+# # FOR SYTHESIZING DATA FOR USE WITH DUMMY MODEL
+
+function make_dummy(; N=10, rng=LehmerRNG(123))
+    X = categorical(vcat(fill('a', N), fill('b', N), fill('c', N)))
+    y = vcat(rand(rng, N), 10*rand(rng, N), 100*rand(rng, N))
+    shuffled = randperm(rng, 3N)
+    return X[shuffled], y[shuffled]
+end
+
+end
+
+ using .DummyModel
+
+# # TEMPORARY TEST AREA
+
+
+
+# using MLJBase
+
+# X, y = make_dummy(N=1000)
+
+# # train in stages:
+# model = DummyIterativeModel(n=4)
+# mach = machine(model, X, y) |> fit!
+# model.n = 9
+# fit!(mach)
+# fp_stages = fitted_params(mach)
+
+# # train in one hit:
+# model = DummyIterativeModel(n=9)
+# mach = machine(model, X, y) |> fit!
+# fp_onehit = fitted_params(mach)
+
+# # compare:
+# @assert fp_onehit == fp_stages
+
+# @assert training_losses(mach) == report(mach).training_losses
+# @assert length(training_losses(mach)) == 9
+
+# # train with lower learning rate:
+# model = DummyIterativeModel(n=9, learning_rate=0.5)
+# mach = machine(model, X, y) |> fit!
+# fp_slow = fitted_params(mach)
+
+# # compare:
+# @assert !(fp_slow.fitresult['a'].avg ≈ fp_onehit.fitresult['a'].avg)

--- a/test/controls.jl
+++ b/test/controls.jl
@@ -1,0 +1,36 @@
+module TestControls
+
+using Test
+using MLJSerialization
+using MLJBase
+using IterationControl
+const IC = IterationControl
+
+using ..DummyModel
+
+@testset "Save" begin
+    X, y = make_dummy(N=8);
+    c = Save("serialization_test.jlso")
+    m = machine(DummyIterativeModel(n=2), X, y)
+    fit!(m, verbosity=0)
+    state = @test_logs((:info, "Saving \"serialization_test1.jlso\". "),
+                       IC.update!(c, m, 1))
+    @test state.filenumber == 1
+    m.model.n = 5
+    fit!(m, verbosity=0)
+    state = IC.update!(c, m, 0, state)
+    @test state.filenumber == 2
+    yhat = predict(IC.expose(m), X);
+
+    deserialized_mach = MLJBase.machine("serialization_test2.jlso")
+    yhat2 = predict(deserialized_mach, X)
+    @test yhat2 ≈ yhat
+
+    train_mach = machine(DummyIterativeModel(n=5), X, y)
+    fit!(train_mach, verbosity=0)
+    @test yhat ≈ predict(train_mach, X)
+end
+
+end
+
+true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,1 +1,11 @@
-include("machines.jl")
+using Test
+
+include("_dummy_model.jl")
+
+@testset "machines" begin
+    include("machines.jl")
+end
+
+@testset "controls" begin
+    include("controls.jl")
+end


### PR DESCRIPTION
Currently there is a `Save` control at MLJIteration. However, that is preventing MLJIteration from bumping its compat to MLJBase 0.18, from which serialization has been removed. So adding it here and removing it in the next MLJIteration release.  