### PR TITLE
Add a check against wrong syntax: `Save(filename="myfile.jlso")`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJSerialization"
 uuid = "17bed46d-0ab5-4cd4-b792-a5c4b8547c6d"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "1.1.0"
+version = "1.1.1"
 
 [deps]
 IterationControl = "b3c1a2ee-3fec-4384-bf48-272ea71de57c"

--- a/src/controls.jl
+++ b/src/controls.jl
@@ -8,8 +8,13 @@ struct Save{K}
 end
 
 # constructor:
-Save(filename="machine.jlso"; kwargs...) =
-    Save(filename, kwargs)
+function Save(filename="machine.jlso"; kwargs...)
+    if :filename in keys(kwargs)
+        error("`filename` is not a keyword argumnent of `Save`. "*
+              "Usage: `Save(filename::String; kwargs...)`. ")
+    end
+    return Save(filename, kwargs)
+end
 
 IterationControl.@create_docs(Save,
              header="Save(filename=\"machine.jlso\"; kwargs...)",
@@ -34,4 +39,3 @@ function IterationControl.update!(c::Save,
     MLJSerialization.save(filename, train_mach, c.kwargs...)
     return (filenumber=filenumber, )
 end
-

--- a/test/controls.jl
+++ b/test/controls.jl
@@ -10,11 +10,12 @@ using ..DummyModel
 
 @testset "Save" begin
     X, y = make_dummy(N=8);
+    @test_throws Exception Save(filename="myfile.jlso")
     c = Save("serialization_test.jlso")
     m = machine(DummyIterativeModel(n=2), X, y)
     fit!(m, verbosity=0)
     state = @test_logs((:info, "Saving \"serialization_test1.jlso\". "),
-                       IC.update!(c, m, 1))
+                       IC.update!(c, m, 2))
     @test state.filenumber == 1
     m.model.n = 5
     fit!(m, verbosity=0)


### PR DESCRIPTION
I got caught by this.